### PR TITLE
Removed sprockets_better_errors from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ group :test, :development do
   gem "capybara"
   gem "selenium-webdriver"
   gem "better_errors"
-  gem "sprockets_better_errors"
   gem "binding_of_caller"
   gem "factory_girl_rails"
   gem "simplecov"


### PR DESCRIPTION
Students who use this lab as the sample app for the Rails Static Request readme/code-along get an error “undefined method lookup_asset_for_path” error when rendering their views. This error is resolved by removing the sprockets_better_errors gem
